### PR TITLE
Generate altitude limits arrays dynamically to support planet adding mods and potential future canonical worlds.

### DIFF
--- a/TimeControl/TimeControl.cs
+++ b/TimeControl/TimeControl.cs
@@ -1180,47 +1180,18 @@ namespace TimeControl
             a.z = temp;
             return a;
         }
-        private int getPlanetaryID(string s) //ID from name
-        {
-            int a = -1;
-
-            if (s == "Sun")
-                a = 0;
-            if (s == "Moho")
-                a = 4;
-            if (s == "Eve")
-                a = 5;
-            if (s == "Gilly")
-                a = 13;
-            if (s == "Kerbin")
-                a = 1;
-            if (s == "Mun")
-                a = 2;
-            if (s == "Minmus")
-                a = 3;
-            if (s == "Duna")
-                a = 6;
-            if (s == "Ike")
-                a = 7;
-            if (s == "Dres")
-                a = 15;
-            if (s == "Jool")
-                a = 8;
-            if (s == "Laythe")
-                a = 9;
-            if (s == "Vall")
-                a = 10;
-            if (s == "Tylo")
-                a = 12;
-            if (s == "Bop")
-                a = 11;
-            if (s == "Pol")
-                a = 14;
-            if (s == "Eeloo")
-                a = 16;
-
-            return a;
-        }
+		private int getPlanetaryID(string s) //ID from name
+		{
+			// 
+			// Change by Nathaniel R. Lewis (aka Teknoman117) (linux.robotdude@gmail.com)
+			//
+			// This method previously hard coded the reference IDs for each planet.  PSystemManager.Instance.localBodies is
+			// a list of the celestial bodies active in KSP.  The index of the body in this list *IS* the reference id.
+			// Method modified to return the reference ID with a predicate search this list.  Enables automatic compatibility
+			// with future planets added by Squad or by planet adding mods such as the upcoming Kopernicus mod.
+			//
+			return PSystemManager.Instance.localBodies.FindIndex (p => p.bodyName.Equals(s));  
+		}
         private float convertToExponential(float a) //1-64 exponential curve
         {
             return Mathf.Clamp(Mathf.Floor(Mathf.Pow(64, a)), 1, 64);

--- a/TimeControl/TimeControlSettings.cs
+++ b/TimeControl/TimeControlSettings.cs
@@ -44,50 +44,67 @@ namespace TimeControl
 
         //Rails warp stuff
         public static string[] customWarpRates = new string[8];
-        public static string[,] customAltitudeLimits = new string[17, 8];
+		public static string[,] customAltitudeLimits = null;
         public static string[] standardWarpRates = { "1", "5", "10", "50", "100", "1000", "10000", "100000" };
-        public static string[,] standardAltitudeLimits = 
-        {
-        {"0","3270000","3270000","6540000","1.308E+07","2.616E+07","5.232E+07","6.54E+07"},
-        {"0","30000","30000","60000","120000","240000","480000","600000"},
-        {"0","5000","5000","10000","25000","50000","100000","200000"},
-        {"0","3000","3000","6000","12000","24000","48000","60000"},
-        {"0","10000","10000","30000","50000","100000","200000","300000"},
-        {"0","30000","30000","60000","120000","240000","480000","600000"},
-        {"0","30000","30000","60000","100000","300000","600000","800000"},
-        {"0","5000","5000","10000","25000","50000","100000","200000"},
-        {"0","0","15000","60000","150000","300000","600000","1200000"},
-        {"0","30000","30000","60000","120000","240000","480000","600000"},
-        {"0","24500","24500","24500","40000","60000","80000","100000"},
-        {"0","24500","24500","24500","40000","60000","80000","100000"},
-        {"0","30000","30000","60000","120000","240000","480000","600000"},
-        {"0","8000","8000","8000","20000","40000","80000","100000"},
-        {"0","5000","5000","5000","8000","12000","30000","90000"},
-        {"0","10000","10000","30000","50000","100000","200000","300000"},
-        {"0","4000","4000","20000","30000","40000","70000","150000"}
-        };
+		public static string[,] standardAltitudeLimits = null;
 
         public static KeyBinding[] keyBinds = { new KeyBinding(KeyCode.None), new KeyBinding(KeyCode.None), new KeyBinding(KeyCode.None), new KeyBinding(KeyCode.None), new KeyBinding(KeyCode.None), new KeyBinding(KeyCode.None) };
 
         private string path = KSPUtil.ApplicationRootPath + "GameData/TimeControl/config.txt";
 
-        private void Start()
-        {
-            config = ConfigNode.Load(path);
-            if (config == null)//file does not exist
-            {
-                buildConfig();
-                loadConfig();
-            }
-            else
-            {
-                loadConfig();
-            }
-        }
-        private void Awake()
-        {
-            UnityEngine.Object.DontDestroyOnLoad(this); //Don't go away on scene changes
-        }
+		//
+		// Change by Nathaniel R. Lewis (aka Teknoman117) (linux.robotdude@gmail.com)
+		// 
+		// I didn't want to tweak too much of the existing code, but since this object is 
+		// invoked as a behavior and not a singleton on first use, we need to guarentee that
+		// the config data is alive before anything makes an attempt to access it.  Putting 
+		// the config loader in Awake() achieves this (for now).
+		//
+		// The custom and standard altitude limit objects are also allocated in Awake() to adjust 
+		// dynamically for future worlds from Squad and from planet adding mods such as the
+		// upcoming Kopernicus mod.
+		// 
+		private void Awake()
+		{
+			// Don't go away on scene changes
+			UnityEngine.Object.DontDestroyOnLoad(this); 
+
+			// Allocate here to account for custom worlds
+			customAltitudeLimits = new string[PSystemManager.Instance.localBodies.Count, 8];
+			standardAltitudeLimits = new string[PSystemManager.Instance.localBodies.Count, 8];
+
+			// Load standard altitude limits from worlds
+			int referenceId = 0;
+			foreach (CelestialBody celestialBody in PSystemManager.Instance.localBodies) 
+			{
+				// We need to convert the altitude limits into strings
+				int index = 0;
+				foreach (float limit in celestialBody.timeWarpAltitudeLimits)
+				{
+					standardAltitudeLimits[referenceId, index++] = Convert.ToInt64(limit).ToString();
+				}
+
+				// Increment reference id
+				referenceId++;
+			}
+
+			// Load config
+			config = ConfigNode.Load(path);
+			if (config == null)//file does not exist
+			{
+				buildConfig();
+				loadConfig();
+			}
+			else
+			{
+				if(loadConfig())
+				{
+					// Config structure was changed, need to save changes
+					saveConfig();
+				}
+			}
+		}
+
         private void Update()
         {
             if ((int)Time.realtimeSinceStartup % 10 == 0) //save every 10 seconds
@@ -160,65 +177,99 @@ namespace TimeControl
 
             config.Save(path);
         }
-        private void loadConfig()
-        {
-            config = ConfigNode.Load(path);
+		private bool loadConfig()
+		{
+			config = ConfigNode.Load(path);
+			bool updatedConfig = false;
 
-            minimized = bool.Parse(config.GetValue("minimized"));
-            visible = bool.Parse(config.GetValue("visible"));
+			minimized = bool.Parse(config.GetValue("minimized"));
+			visible = bool.Parse(config.GetValue("visible"));
 
-            ConfigNode flightWindowPositionNode = config.GetNode("flightWindowPosition");
-            flightWindowPosition.xMin = float.Parse(flightWindowPositionNode.GetValue("xMin"));
-            flightWindowPosition.xMax = float.Parse(flightWindowPositionNode.GetValue("xMax"));
-            flightWindowPosition.yMin = float.Parse(flightWindowPositionNode.GetValue("yMin"));
-            flightWindowPosition.yMax = float.Parse(flightWindowPositionNode.GetValue("yMax"));
+			ConfigNode flightWindowPositionNode = config.GetNode("flightWindowPosition");
+			flightWindowPosition.xMin = float.Parse(flightWindowPositionNode.GetValue("xMin"));
+			flightWindowPosition.xMax = float.Parse(flightWindowPositionNode.GetValue("xMax"));
+			flightWindowPosition.yMin = float.Parse(flightWindowPositionNode.GetValue("yMin"));
+			flightWindowPosition.yMax = float.Parse(flightWindowPositionNode.GetValue("yMax"));
 
-            ConfigNode menuWindowPositionNode = config.GetNode("menuWindowPosition");
-            menuWindowPosition.xMin = float.Parse(menuWindowPositionNode.GetValue("xMin"));
-            menuWindowPosition.xMax = float.Parse(menuWindowPositionNode.GetValue("xMax"));
-            menuWindowPosition.yMin = float.Parse(menuWindowPositionNode.GetValue("yMin"));
-            menuWindowPosition.yMax = float.Parse(menuWindowPositionNode.GetValue("yMax"));
+			ConfigNode menuWindowPositionNode = config.GetNode("menuWindowPosition");
+			menuWindowPosition.xMin = float.Parse(menuWindowPositionNode.GetValue("xMin"));
+			menuWindowPosition.xMax = float.Parse(menuWindowPositionNode.GetValue("xMax"));
+			menuWindowPosition.yMin = float.Parse(menuWindowPositionNode.GetValue("yMin"));
+			menuWindowPosition.yMax = float.Parse(menuWindowPositionNode.GetValue("yMax"));
 
-            ConfigNode settingsWindowPositionNode = config.GetNode("settingsWindowPosition");
-            settingsWindowPosition.xMin = float.Parse(settingsWindowPositionNode.GetValue("xMin"));
-            settingsWindowPosition.xMax = float.Parse(settingsWindowPositionNode.GetValue("xMax"));
-            settingsWindowPosition.yMin = float.Parse(settingsWindowPositionNode.GetValue("yMin"));
-            settingsWindowPosition.yMax = float.Parse(settingsWindowPositionNode.GetValue("yMax"));
+			ConfigNode settingsWindowPositionNode = config.GetNode("settingsWindowPosition");
+			settingsWindowPosition.xMin = float.Parse(settingsWindowPositionNode.GetValue("xMin"));
+			settingsWindowPosition.xMax = float.Parse(settingsWindowPositionNode.GetValue("xMax"));
+			settingsWindowPosition.yMin = float.Parse(settingsWindowPositionNode.GetValue("yMin"));
+			settingsWindowPosition.yMax = float.Parse(settingsWindowPositionNode.GetValue("yMax"));
 
-            ConfigNode fpsPositionNode = config.GetNode("fpsPosition");
-            fpsPosition.xMin = float.Parse(fpsPositionNode.GetValue("xMin"));
-            fpsPosition.xMax = float.Parse(fpsPositionNode.GetValue("xMax"));
-            fpsPosition.yMin = float.Parse(fpsPositionNode.GetValue("yMin"));
-            fpsPosition.yMax = float.Parse(fpsPositionNode.GetValue("yMax"));
+			ConfigNode fpsPositionNode = config.GetNode("fpsPosition");
+			fpsPosition.xMin = float.Parse(fpsPositionNode.GetValue("xMin"));
+			fpsPosition.xMax = float.Parse(fpsPositionNode.GetValue("xMax"));
+			fpsPosition.yMin = float.Parse(fpsPositionNode.GetValue("yMin"));
+			fpsPosition.yMax = float.Parse(fpsPositionNode.GetValue("yMax"));
 
-            mode = int.Parse(config.GetValue("mode"));
-            camFix = bool.Parse(config.GetValue("camFix"));
-            fpsKeeperActive = bool.Parse(config.GetValue("fpsKeeperActive"));
-            fpsMinSlider = int.Parse(config.GetValue("fpsMinSlider"));
-            showFPS = bool.Parse(config.GetValue("showFPS"));
+			mode = int.Parse(config.GetValue("mode"));
+			camFix = bool.Parse(config.GetValue("camFix"));
+			fpsKeeperActive = bool.Parse(config.GetValue("fpsKeeperActive"));
+			fpsMinSlider = int.Parse(config.GetValue("fpsMinSlider"));
+			showFPS = bool.Parse(config.GetValue("showFPS"));
 
-            ConfigNode keyBindsNode = config.GetNode("keyBinds");
-            for (int i = 0; i < keyBinds.Length; i++)
-            {
-                keyBinds[i].primary = (KeyCode)Enum.Parse(typeof(KeyCode), keyBindsNode.GetValue("keyBind" + i));
-            }
+			ConfigNode keyBindsNode = config.GetNode("keyBinds");
+			for (int i = 0; i < keyBinds.Length; i++)
+			{
+				keyBinds[i].primary = (KeyCode)Enum.Parse(typeof(KeyCode), keyBindsNode.GetValue("keyBind" + i));
+			}
 
-            ConfigNode customWarpRatesNode = config.GetNode("customWarpRates");
-            for (int i = 0; i < customWarpRates.Length; i++)
-            {
-                customWarpRates[i] = customWarpRatesNode.GetValue("customWarpRate" + i);
-            }
+			ConfigNode customWarpRatesNode = config.GetNode("customWarpRates");
+			for (int i = 0; i < customWarpRates.Length; i++)
+			{
+				customWarpRates[i] = customWarpRatesNode.GetValue("customWarpRate" + i);
+			}
 
-            ConfigNode customAltitudeLimitsNode = config.GetNode("customAltitudeLimits");
-            for (int i = 0; i < customAltitudeLimits.GetLength(0); i++)
-            {
-                ConfigNode celestial = customAltitudeLimitsNode.GetNode("celestial" + i);
-                for (int j = 0; j < customAltitudeLimits.GetLength(1); j++)
-                {
-                    customAltitudeLimits[i,j] = celestial.GetValue("customAltitudeLimit" + j);
-                }
-            }
-        }
+			//
+			// Change by Nathaniel R. Lewis (aka Teknoman117) (linux.robotdude@gmail.com)
+			// 
+			// Previous implementation of this section of this method based assumed all celestial entries 
+			// would be present.  In the event the planetary system changes between loads of this file,
+			// the loader would break attempting to parse a non-existant node.
+			//
+			// New implementation checks if the desired altitude limit node is present.  If not, it loads
+			// the standard limit for that body.  When this occurs, the flag "updatedConfig" is set to 
+			// indicate that the config file needs to be saved.  This ensures compatibility with future 
+			// worlds from Squad and from planet adding mods such as the upcoming Kopernicus mod.
+			// 
+			ConfigNode customAltitudeLimitsNode = config.GetNode("customAltitudeLimits");
+			for (int i = 0; i < customAltitudeLimits.GetLength(0); i++)
+			{
+				string celestialName = ("celestial" + i);
+
+				// If the config file has an entry for this celestial body, load it
+				if(customAltitudeLimitsNode.HasNode(celestialName))
+				{
+					ConfigNode celestial = customAltitudeLimitsNode.GetNode(celestialName);
+					for (int j = 0; j < customAltitudeLimits.GetLength(1); j++)
+					{
+						customAltitudeLimits[i,j] = celestial.GetValue("customAltitudeLimit" + j);
+					}
+				}
+
+				// Otherwise we need to load it from the defaults and set the updatedConfig flag (handle planet changing)
+				else
+				{
+					updatedConfig = true;
+					ConfigNode celestial = customAltitudeLimitsNode.AddNode(celestialName);
+					for (int j = 0; j < customAltitudeLimits.GetLength(1); j++)
+					{
+						customAltitudeLimits[i,j] = standardAltitudeLimits[i,j];
+						celestial.AddValue("customAltitudeLimit" + j, standardAltitudeLimits[i,j]);
+					}
+				}
+			}
+
+			// Return whether we updated the config (added more bodies)
+			return updatedConfig;
+		}
         private void saveConfig()
         {
             config.SetValue("minimized", minimized.ToString());


### PR DESCRIPTION
Modified TimeControlSettings.cs to generate altitude limit arrays dynamically, taking into account the number of bodies that are in the game.  Modified TimeControl.getPlanetaryID(string) to search the localBodies list for reference ids instead of hard coding values, the the body's index in localBodies _IS_ the reference body id.

These changes enable support for future planets Squad may or may not add, and for planet adding mods such as the upcoming Kopernicus mod.  Planet Factory probably won't play nice due to its own implementation of warp level modification.
