### PR TITLE
Avoid saving settings repeatedly every frame

### DIFF
--- a/TimeControl/TimeControlSettings.cs
+++ b/TimeControl/TimeControlSettings.cs
@@ -61,6 +61,9 @@ namespace TimeControl
 
         private string path = KSPUtil.ApplicationRootPath + "GameData/TimeControl/config.txt";
 
+        private float lastSave = 0f;
+        private float saveInterval = 10f;
+
 		private void Start()
 		{
 			UnityEngine.Object.DontDestroyOnLoad(this);
@@ -103,8 +106,12 @@ namespace TimeControl
 
         private void Update()
         {
-            if ((int)Time.realtimeSinceStartup % 10 == 0) //save every 10 seconds
+            float now = Time.realtimeSinceStartup;
+
+            if (now - lastSave > saveInterval)
             {
+                lastSave = now;
+
                 GameSettings.PHYSICS_FRAME_DT_LIMIT = maxDeltaTimeSlider;
                 GameSettings.SaveSettings();
 


### PR DESCRIPTION
Currently `TimeControl.Settings.Update` is supposed to save settings every 10 seconds. But the way the function is currently written, settings are saved _every frame_ for 1 out of every 10 seconds, because `Update` is called every frame, and the `if` statement condition will evaluate to `true` for every single frame if the `int` part of the current second is zero. On my system, I get about 50-60 calls to `GameSettings.SaveSettings` and `TimeControl.Settings.saveConfig` every 10 seconds because I'm getting 50-60 fps.

I've rewritten the function so it actually only saves once every 10 seconds. There's still probably a lot more that could be done to improve this this (e.g. don't check the time on _every single frame_; only save settings if any of them actually changed; etc.). But at the very least, this change makes the function behave as intended.
